### PR TITLE
Fix pivot links to task/language

### DIFF
--- a/components/pivot.tsx
+++ b/components/pivot.tsx
@@ -70,7 +70,7 @@ export let ProgramView = ({program, headers, ...props}) => {
   return <div className='program-container'>
     <h3>{headers.map(k => {
         let val = _.find(k == 'task' ? TASKS : LANGUAGES, {id: program[k]});
-        return <Link href={`/${k}/val.id`}>{val.name}</Link>
+        return <Link href={`/${k}/${val.id}`}>{val.name}</Link>
     }).reduce((l, r) => [l, ' / ', r])}</h3>
     <Code program={program} width={'100%'} task={task}
           {...props} />


### PR DESCRIPTION
I couldn't test this (I got an error that Python 3.12 isn't supported) but hopefully it works.

You can see the bug by looking at any of the task links at https://willcrichton.net/expressiveness-benchmark/lang/python-pandas for example.