### PR TITLE
[ci] Update workflow versions

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: cd code_widget && npm install && npm run build && cd ..
       - run: npm install && npm run build
       - uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
In order to redeploy we have to use a newer runner image, ubuntu-18.04 seems to be gone since about a year ago.

I didn't test this, it's possible that on the newer version of node that ubuntu-22.04 provides the build won't work.